### PR TITLE
Fixes #51

### DIFF
--- a/common/src/main/java/com/github/cao/awa/sepals/world/poi/SepalsPointOfInterestStorage.java
+++ b/common/src/main/java/com/github/cao/awa/sepals/world/poi/SepalsPointOfInterestStorage.java
@@ -19,7 +19,10 @@ import net.minecraft.world.poi.PointOfInterestSet;
 import net.minecraft.world.poi.PointOfInterestStorage;
 import net.minecraft.world.poi.PointOfInterestType;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiPredicate;
@@ -231,10 +234,15 @@ public class SepalsPointOfInterestStorage {
             Random random
     ) {
         Catheter<PointOfInterest> catheter = getInCircle(storage, typePredicate, pos, radius, occupationStatus);
-        catheter.shuffle(random::nextLong);
+
+        List<PointOfInterest> list = new ArrayList<>();
+        catheter.each(list::add);
+        Collections.shuffle(list, new java.util.Random(random.nextLong()));
+
         return Optional.ofNullable(
-                catheter.filter(poi -> positionPredicate.test(poi.getPos()))
-                        .findFirst(x -> true)
+                list.stream().filter(poi -> positionPredicate.test(poi.getPos()))
+                        .findFirst()
+                        .orElse(null)
         ).map(PointOfInterest::getPos);
     }
 


### PR DESCRIPTION
Why: The java.lang.IllegalArgumentException occurs because catheter.shuffle() uses a non-deterministic comparison (likely due to random::nextLong), which violates the Java TimSort contract. This was reproduced via unit test.

What I did:

Collected PointOfInterest elements into a local ArrayList to "freeze" the state.

Replaced the unstable shuffle with Collections.shuffle on this stable list to satisfy the sorting contract.

P.S. I’m new to open source! I noticed the Catheter API lacks a native .toList() method; I'm happy to contribute that fix to the other repo if preferred.